### PR TITLE
11.0 mig quality control stock security

### DIFF
--- a/quality_control_stock/__manifest__.py
+++ b/quality_control_stock/__manifest__.py
@@ -20,6 +20,7 @@
         "stock",
     ],
     "data": [
+        "security/ir.model.access.csv",
         "data/quality_control_stock_data.xml",
         "views/qc_inspection_view.xml",
         "views/stock_picking_view.xml",

--- a/quality_control_stock/security/ir.model.access.csv
+++ b/quality_control_stock/security/ir.model.access.csv
@@ -1,0 +1,8 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_user_qc_inspection_stock_user,qc_inspection stock user,quality_control.model_qc_inspection,stock.group_stock_user,1,1,1,0
+access_user_qc_inspection_line_stock_user,qc_inspection_line stock user,quality_control.model_qc_inspection_line,stock.group_stock_user,1,1,1,0
+access_user_qc_test_stock_user,qc_test stock_user,quality_control.model_qc_test,stock.group_stock_user,1,0,0,0
+access_user_qc_test_question_stock_user,qc_test_question stock user,quality_control.model_qc_test_question,stock.group_stock_user,1,0,0,0
+access_user_qc_test_question_value_stock_user,qc_test_question_value_stock_user,quality_control.model_qc_test_question_value,stock.group_stock_user,1,0,0,0
+access_manager_qc_trigger_stock_user,qc_trigger stock user,quality_control.model_qc_trigger,stock.group_stock_user,1,0,0,0
+access_manager_qc_trigger_product_category_line_stock_user,qc_trigger product_category line stock user,quality_control.model_qc_trigger_product_category_line,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
Hello @NachoAlesLopez Please can you add this PR?

create quality control inspection without necessarily being
quality control user. It is common that the person doing the
picking is not going to be the same as the one doing the inspection.

So when a stock user create the transfer, the system will create
the necessary qc inspections, regardless if the user has permissions
to process them.